### PR TITLE
Added a cache logic to location.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.txt
 *test*
+*.json
 
 # FOLDERS
 __pycache__

--- a/utils/location.py
+++ b/utils/location.py
@@ -1,9 +1,36 @@
 import requests
+import json
+import os
 
-def get_lat_long(address):
-    """This function takes an address as input and return the lat long 
-       coordinates using OpenStreetMap's Nominatim API."""
-    
+CACHE_FILE = "location_cache.json"
+
+# Load existing cache from file
+if os.path.exists(CACHE_FILE):
+    with open(CACHE_FILE, "r") as f:
+        cache = json.load(f)
+else:
+    cache = {}
+
+def save_cache():
+    """Save the current cache dictionary to disk."""
+    with open(CACHE_FILE, "w") as f:
+        json.dump(cache, f)
+
+def normalize_address(address: str) -> str:
+    """Normalize address strings to reduce duplicate cache entries."""
+    return address.strip().lower()
+
+def get_lat_long(address: str):
+    """
+    Return (lat, lon) for a given address using OpenStreetMap's Nominatim API.
+    Uses a persistent JSON cache to minimize API calls and prevent rate-limiting.
+    """
+    address_key = normalize_address(address)
+
+    # Return cached result if it exists
+    if address_key in cache:
+        return cache[address_key]
+
     url = "https://nominatim.openstreetmap.org/search"
     params = {
         "q": address,
@@ -11,15 +38,22 @@ def get_lat_long(address):
         "limit": 1
     }
     headers = {"User-Agent": "discord-bot-collab/1.0 (your_email@example.com)"}
+
     try:
         response = requests.get(url, params=params, headers=headers, timeout=10)
         response.raise_for_status()
         data = response.json()
+
         if data:
-            lat = data[0]['lat']
-            lon = data[0]['lon']
-            return lat, lon
+            lat, lon = data[0]['lat'], data[0]['lon']
+            cache[address_key] = (lat, lon)
         else:
-            return None, None
-    except Exception as e:
-        return None, None
+            cache[address_key] = (None, None)
+
+    except Exception:
+        cache[address_key] = (None, None)
+
+    # Save cache to disk after each new lookup
+    save_cache()
+
+    return cache[address_key]


### PR DESCRIPTION
Created a cache logic within the `location.py` file to store searched locations, minimising repeated API pull requests from [OpenStreetMap](https://nominatim.openstreetmap.org/search) as OpenStreetMap allows a certain amount of requests within a short period of time from one IP address, minimising the amount of **"Could not find coordinates for..."** errors from occurring when stress testing and general bot use. 

By adding this logic to `location.py`, there is no need to change the logic of slash commands. 